### PR TITLE
copy and realloc token in same pass 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 valery
 tags
 utils/exp/
+issues.txt

--- a/utils/exec.c
+++ b/utils/exec.c
@@ -79,7 +79,7 @@ int valery_exec_buffer(struct tokens_t *tokens, struct ENV *env)
 
         if (tokens->token_type[pos] != O_NONE) {
             fprintf(stderr, "valery: invalid starting token '%s'\n", tokens->token_arr[pos]);
-            rc = 1;
+            rc = 2;
             break;
         }
         /* set cmd to be first token */

--- a/utils/lexer.c
+++ b/utils/lexer.c
@@ -93,6 +93,7 @@ void tokenize(struct tokens_t *tokens, char *buf)
 {
     const char delim[] = " ";
     char *token = strtok(buf, delim);
+    size_t token_len;
 
     while (token != NULL) {
         /* check if space for token and if and more memory needs to be allocated */
@@ -100,16 +101,19 @@ void tokenize(struct tokens_t *tokens, char *buf)
             increase_tokens_amount(tokens, tokens->len + 32);
         }
 
-        /* TODO: avoid strlen by copying and reallocing (if necessary) in same pass ? */
-        /* +1 to account for null byte */
-        size_t token_len = strlen(token) + 1;
-        if (token_len >= tokens->allocated_size[tokens->i]) {
-            increase_token_size(tokens, token_len + 1);
-        }
+        token_len = 0;
+        do {
+            tokens->token_arr[tokens->i][token_len] = *token;
+            if (token_len++ == tokens->allocated_size[tokens->i])
+                increase_token_size(tokens, token_len + 32);
+        } while (*(++token) != 0);
+
+        /* add null byte */
+        tokens->token_arr[tokens->i][token_len] = 0;
 
         tokens->token_type[tokens->i] = get_token_operand(token);
-        strncpy(tokens->token_arr[tokens->i++], token, token_len + 1);
         token = strtok(NULL, delim);
+        tokens->i++;
     }
 
 }

--- a/valery.c
+++ b/valery.c
@@ -122,8 +122,9 @@ int main()
         putchar('\n');
 
         rc = valery_exec_buffer(tokens, env);
-        if (rc == 1)
-            printf("valery: command not found: %s\n", cmd);
+        // dealt with in valery_exec_buffer
+        //if (rc == 1)
+        //    printf("valery: command not found: %s\n", cmd);
 
         env->exit_code = rc;
         save_command(hist, input_buffer);

--- a/valery.c
+++ b/valery.c
@@ -117,7 +117,6 @@ int main()
         struct tokens_t *tokens = malloc_tokens_t();
         tokenize(tokens, input_buffer);
 
-
         /* start output of execution of buffer on new line */
         putchar('\n');
 


### PR DESCRIPTION
strlen followed by strncpy would mean we pass through the string twice, when we really only need to do it once. Should be faster.