### PR TITLE
feat: crude stream redirect using pipe symbol

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -19,15 +19,14 @@ jobs:
           sudo apt-get update -qyy
           sudo apt-get install valgrind
 
+      - name: Build
+        run: ./build.sh debug
+
       - name: Test   
         if: startswith(matrix.os, 'ubuntu-')
         run: |
           cp .valeryrc ~/
-          ./build.sh debug
           ./tests/memory_leak_test.sh
-
-      - name: Build
-        run: ./build.sh
 
       - name: Run
         run: ./valery --help

--- a/builtins/help.c
+++ b/builtins/help.c
@@ -33,6 +33,8 @@ int help()
         printf("%s  ", builtin_names[i]);
     }
 
+    printf("\n\nUse the -c option to execute a command directly when envoking valery. Example: './valery -c \"ls\"'\n");
+
     printf("\n");
     return 0;
 }

--- a/builtins/history.c
+++ b/builtins/history.c
@@ -38,14 +38,14 @@ int history(struct hist_t *hist)
     if (histlines == 0)
         return 1;
 
-    reset_hist_pos(hist);
+    hist_t_reset_pos(hist);
     /* only read valid amount of histlines */
     len = histlines >= LINES ? LINES : histlines;
     for (i = len; i > 0; i--)
-        traverse_hist(hist, HIST_UP); 
+        hist_t_traverse(hist, HIST_UP); 
 
     for (i = len; i > 1; i--) {
-        rc = get_hist_line(hist, buf, HIST_DOWN);
+        rc = hist_t_get_line(hist, buf, HIST_DOWN);
         /* chop off new line character */
         if (rc == READ_FROM_HIST)
             buf[strlen(buf) - 1] = 0;

--- a/utils/exec.h
+++ b/utils/exec.h
@@ -56,13 +56,18 @@ typedef struct exec_ctx {
  * calls the builtin 'which' (builtin/which.c) to get the full program path.
  * returns 0 if succesfull, else 1.
  */
-int valery_exec_program(char *program_name, char *argv[], int argc, struct env_t *env);
+int valery_exec_program(char *program_name, char *argv[], int argc, struct env_t *env, struct exec_ctx *e_ctx);
 
+//TODO THIS IS STUPID AND I #hateit
 /* evalutes how the tokens should be executed */
-int valery_eval_token(char *program_name, char *argv[], int argc, struct env_t *env, struct hist_t *hist);
+int valery_eval_token(char *program_name, char *argv[], int argc, struct env_t *env, struct hist_t *hist, struct exec_ctx *e_ctx);
 
 /* parses the tokens and calls eval on them accordingly */
 int valery_parse_tokens(struct tokenized_str_t *ts, struct env_t *env, struct hist_t *hist);
+
+int str_to_argv(char *str, char **argv, int *argv_cap);
+
+void update_exec_flags(struct exec_ctx *e_ctx, operands_t type, operands_t next_type);
 
 /*
  * how the three aformentioned functions relate to each other:

--- a/utils/exec.h
+++ b/utils/exec.h
@@ -24,6 +24,31 @@
 #include "../valery.h"
 
 #define CHILD_PID 0
+#define READ_END 0
+#define WRITE_END 1
+
+/* types */
+typedef enum stream_flags {
+    STREAM1_VACANT      = 1 << 0,
+    STREAM1_CLOSE       = 1 << 1,
+    STREAM2_VACANT      = 1 << 2,
+    STREAM2_CLOSE       = 1 << 3,
+    NEXT_IS_PIPE        = 1 << 4,
+    CAME_FROM_PIPE      = 1 << 5,
+    NEXT_IS_REDIRECT    = 1 << 6,
+    CAME_FROM_REDIRECT  = 1 << 7
+} stream_flags;
+
+
+/*
+ * keeps track of stream flags that determine where input and output is directed.
+ */
+typedef struct exec_ctx {
+    int stream1[2];
+    int stream2[2];
+    int flags;
+} exec_ctx;
+
 
 /* functions */
 /*

--- a/utils/histfile.h
+++ b/utils/histfile.h
@@ -48,57 +48,51 @@ typedef enum {
  * HIST_UP: decrements pos by one.
  * HIST_DOWN: increments pos by one.
  *
- * use init_history() and free_history() to create and free hist_t types.
+ * use init_history() and hist_t_free() to create and free hist_t types.
  */
 typedef struct hist_t {
     FILE *fp;
-    /* newest last */
-    char **stored_commands;
-    /* total stored commands in memory */
-    size_t s_len;
-    /* absolute position in history queue */
-    size_t pos;
-    /* position of file pointer in history queue */
-    size_t f_pos;
-    /* amount of lines in hist file */
-    size_t f_len;
-    /* amount of chars in hist file */
-    size_t f_chars;
+    char **stored_commands; /* newest last */
+    size_t s_len;           /* total stored commands in memory */
+    size_t pos;             /* absolute position in history queue */
+    size_t f_pos;           /* position of file pointer in history queue */
+    size_t f_len;           /* amount of lines in hist file */
+    size_t f_chars;         /* amount of chars in hist file */
 } hist_t;
 
 
 /* functions */
 
 /* returns a pointer of type hist_t with malloced data */
-struct hist_t *malloc_history(char *full_pat_to_hist_file);
+struct hist_t *hist_t_malloc(char *full_pat_to_hist_file);
 
 /* frees the data associated with the hist_t pointer passed in */
-void free_history(struct hist_t *hist);
+void hist_t_free(struct hist_t *hist);
 
 /* moves file pointer to the end and resets position counters */
-void reset_hist_pos(struct hist_t *hist);
+void hist_t_reset_pos(struct hist_t *hist);
 
 /* stores the input buffer into memory */
-void save_command(struct hist_t *hist, char buf[COMMAND_LEN]);
+void hist_t_save(struct hist_t *hist, char buf[COMMAND_LEN]);
 
 /* 
  * writes the stored commands to the hist file connection and clears
  * data from memory.
  */
-void write_commands_to_hist_file(struct hist_t *hist);
+void hist_t_write(struct hist_t *hist);
 
 /* 
- * returns the amount of lines in the file and in the process moves
+ * stores the amount of lines in the file and in the process moves
  * the file pointer to the end of the file.
  */
-void count_hist_lines(struct hist_t *hist);
+void hist_t_count(struct hist_t *hist);
 
 /*
  * traverses the hist one line in the given direction.
  * NB: function does not make sure direction does not cause
  * hist to go out of bounds.
  */
-long traverse_hist(struct hist_t *hist, histaction_t direction);
+long hist_t_traverse(struct hist_t *hist, histaction_t direction);
 
 /* returns 1 if the given action will put the file pointer out of
  * bounds, else 0.
@@ -110,19 +104,19 @@ int out_of_bounds(struct hist_t *hist, histaction_t action);
  * creates a new hist file if input path does not exist.
  * returns 1 if no connection could be made, else 0.
  */
-int open_hist_file(struct hist_t *hist, char *path);
+int hist_t_open(struct hist_t *hist, char *path);
 
 /*
  * reads one line of the hist file and moves the file pointer back to the given offset.
  * if offset is -1, it uses ftell(hist->fp) to get the offset
  */
-void read_hist_line_from_file(struct hist_t *hist, char buf[COMMAND_LEN], long offset, histaction_t action);
+void hist_t_read_line_f(struct hist_t *hist, char buf[COMMAND_LEN], long offset, histaction_t action);
 
 /*
  * puts the current hist line into the buf argument.
  * returns where it got the hist line from (see definitions on the 
  * top of the file).
  */
-readfrom_t get_hist_line(struct hist_t *hist, char buf[COMMAND_LEN], histaction_t action);
+readfrom_t hist_t_get_line(struct hist_t *hist, char buf[COMMAND_LEN], histaction_t action);
 
 #endif

--- a/utils/lexer.h
+++ b/utils/lexer.h
@@ -51,14 +51,14 @@ typedef struct token_t {
     char *str_start;          /* points to the start of the string */
     enum operands_t type;     /* the semantic intepretation of the token */
     size_t str_len;           /* the current len of the token string without counting terminating null byte */
-    size_t str_allocated;     /* the allocated size of the token string */
+    size_t str_capacity;      /* the allocated capcity of the token string */
 } token_t;
 
 
 typedef struct tokenized_str_t {
     struct token_t **tokens;  /* list of the tokens */
-    size_t total_tokens;      /* actual total tokens in the token list */
-    size_t tokens_allocated;  /* totoal allocated tokens */
+    size_t size;              /* total blocks of tokens occupied / in use */
+    size_t capacity;          /* total blocks of tokens allocated */
 } tokenized_str_t;
 
 
@@ -73,14 +73,14 @@ struct token_t *token_t_malloc();
 
 void token_t_free(struct token_t *t);
 
-void token_t_resize(struct token_t *t, size_t new_size);
+void token_t_resize(struct token_t *t, size_t new_capacity);
 
 /* returns a pointer to a malloced tokenized_str_t object with STARTING_TOKENS amount of token_t */
 struct tokenized_str_t *tokenized_str_t_malloc();
 
 void tokenized_str_t_free(struct tokenized_str_t *ts);
 
-void tokenized_str_t_resize(struct tokenized_str_t *ts, size_t new_size);
+void tokenized_str_t_resize(struct tokenized_str_t *ts, size_t new_capacity);
 
 /*
  * 'cleans' the object and makes it act as though it has just been malloced.
@@ -102,7 +102,7 @@ void token_t_pop_char(struct token_t *t);
 void tokenized_str_t_append_char(struct tokenized_str_t *ts, char c);
 
 /* 
- * increments total_tokens and returns a pointer to the next token_t
+ * increments size and returns a pointer to the next token_t
  * calls tokenized_str_t_resize() if necessary.
  */
 struct token_t *tokenized_str_t_next(struct tokenized_str_t *ts);

--- a/utils/lexer.h
+++ b/utils/lexer.h
@@ -108,6 +108,9 @@ void tokenized_str_t_append_char(struct tokenized_str_t *ts, char c);
 struct token_t *tokenized_str_t_next(struct tokenized_str_t *ts);
 
 /* just for debugging */
+void token_t_print(struct token_t *t);
+
+/* just for debugging */
 void tokenized_str_t_print(struct tokenized_str_t *ts);
 
 /*

--- a/utils/prompt.c
+++ b/utils/prompt.c
@@ -106,7 +106,7 @@ int prompt(struct hist_t *hist, char *ps1, char buf[COMMAND_LEN])
 
     print_prompt(ps1, buf);
     /* reset position in history to bottom of queue */
-    reset_hist_pos(hist);
+    hist_t_reset_pos(hist);
 
     while (EOF != (ch = getchar()) && ch != '\n') {
         /* return if buffer cannot store more chars */

--- a/utils/prompt.c
+++ b/utils/prompt.c
@@ -134,7 +134,7 @@ int prompt(struct hist_t *hist, char *ps1, char buf[COMMAND_LEN])
                 /* execution enters here means either arrow up or down was pressed */
                 /* store hist line inside buf */
                 action = (arrow_type == ARROW_UP) ? HIST_UP : HIST_DOWN;
-                rc = get_hist_line(hist, buf, action);
+                rc = hist_t_get_line(hist, buf, action);
 
                 if (rc == DID_NOT_READ && action == HIST_DOWN) {
                     /* clear buffer when no hist line was read */

--- a/valery.c
+++ b/valery.c
@@ -119,7 +119,7 @@ int exclusive(char *arg)
     }
 
     snprintf(hist_file_path, MAX_ENV_LEN, "%s/%s", env->HOME, HISTFILE_NAME);
-    hist = malloc_history(hist_file_path);
+    hist = hist_t_malloc(hist_file_path);
 
     ts = tokenized_str_t_malloc();
     rc = tokenize(ts, arg);
@@ -129,7 +129,7 @@ int exclusive(char *arg)
     }
 
     free_env(env);
-    free_history(hist);
+    hist_t_free(hist);
     tokenized_str_t_free(ts);
 
     return rc_env;
@@ -158,7 +158,7 @@ int interactive()
 
     /* establish a connection to the hist file */
     snprintf(hist_file_path, MAX_ENV_LEN, "%s/%s", env->HOME, HISTFILE_NAME);
-    hist = malloc_history(hist_file_path);
+    hist = hist_t_malloc(hist_file_path);
 
     /* create tokenized_str_t object. Will reused same object every loop. */
     ts = tokenized_str_t_malloc();
@@ -174,7 +174,7 @@ int interactive()
             goto end_loop;
         }
 
-        save_command(hist, input_buffer);
+        hist_t_save(hist, input_buffer);
 
         if (strcmp(input_buffer, "") == 0)
             goto end_loop;
@@ -195,9 +195,9 @@ int interactive()
     }
 
     /* free and write to file before exiting */
-    write_commands_to_hist_file(hist);
+    hist_t_write(hist);
     free_env(env);
-    free_history(hist);
+    hist_t_free(hist);
     tokenized_str_t_free(ts);
 
     printf("Exiting ...\n");

--- a/valery.c
+++ b/valery.c
@@ -125,7 +125,7 @@ int exclusive(char *arg)
     rc = tokenize(ts, arg);
     if (rc == 0) {
         rc_env = valery_parse_tokens(ts, env, hist);
-        env->exit_code = rc_env;
+        //env->exit_code = rc_env;
     }
 
     free_env(env);
@@ -185,7 +185,7 @@ int interactive()
         rc = tokenize(ts, input_buffer);
         if (rc == 0) {
             rc_env = valery_parse_tokens(ts, env, hist);
-            env->exit_code = rc_env;
+            //env->exit_code = rc_env;
         }
 
     /* clears all buffers */


### PR DESCRIPTION
This PR will solve #27 and #32.

This PR will also rename variables for structs that have the concept of "allocated vs size".

For example, the `tokenized_str_t` struct has a field for `total_allocated` and `total_tokens`, where `total_allocated` is the total amount of allocated memory blocks, and `total_tokens` is the total amount of memory blocks that are in use. Rename this to `size` and `capacity` respectively. Same applies to other structs.